### PR TITLE
Previous version doesn't yield correct value

### DIFF
--- a/_posts/2016-03-08-partial-function-application-and-currying-in-ruby.md
+++ b/_posts/2016-03-08-partial-function-application-and-currying-in-ruby.md
@@ -68,7 +68,7 @@ What if we want to multiply more than two arguments?
 To prevent this, we can change multiply function and use *Proc#curry* method:
 
 {% highlight ruby %}
-  multiply = -> (head, *tail) { head || 1 * tail.inject(1, &:*) }
+  multiply = -> (head, *tail) { head * tail.inject(1, &:*) }
   multiply.curry.(2, 2, 2) # 8
   multiply.curry.(2, 3, 7) # 42
 {% endhighlight %}


### PR DESCRIPTION
The logic looked a bit odd when I read it and it doesn't yield the expected results. Removing the or condition seems to solve the issue.

Ruby version:
`ruby 2.3.4p301 (2017-03-30 revision 58214) [x86_64-linux]`